### PR TITLE
Buffs the biogenerator

### DIFF
--- a/code/modules/biomatter_manipulation/biogenerator.dm
+++ b/code/modules/biomatter_manipulation/biogenerator.dm
@@ -70,7 +70,7 @@
 		var/biomatter_amount = 1/max(1, port.pipes_dirtiness)
 		port.tank.reagents.remove_reagent("biomatter", biomatter_amount)
 		generator.chamber.consume_and_produce()
-		var/output_power = 200000
+		var/output_power = 500000
 
 		//port wearout
 		port.working_cycles++


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Buffs the biogenerators maximum output power from 200k to 500k. I can't recall using or seing anyone use it, and there was a request in the discord
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should encourage people to actually use the biogenerator, as a backup power source after the SM gets vented or something
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: changes the biogenerators output_power from 200k to 500k
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
